### PR TITLE
speed up sparse write, fix bug in Set Element testing, make SL4 public

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,3 +1,4 @@
 from __future__ import absolute_import
 from .harpy.HAR import HAR
 from .harpy.Header import Header
+from .harpy.SL4 import SL4

--- a/harpy/HAR_IO.py
+++ b/harpy/HAR_IO.py
@@ -390,19 +390,22 @@ class HAR_IO(object):
             self.f.write(struct.pack('=i4siiii', 16, tb('    '), 1, 0, 0, 16))
             return
 
-        for i, val in enumerate(array.flatten('F')):
-            if val != 0:
-                ndata += 1
-                indexList.append(i + 1)
-                valList.append(val)
-                if ndata == maxData:
-                    self.writeSparseList(NNonZero, dtype, indexList, ndata, nrec, valList)
-                    nrec = nrec - 1;
-                    indexList = [];
-                    valList = [];
-                    ndata = 0
+        indexList=maxData*[None]
+        valList=maxData*[None]
+        tmp=array.flatten('F')
+        nzind=np.nonzero(tmp)
+        for i in nzind[0]:
+            ndata += 1
+            indexList[ndata-1]=i
+            valList[ndata-1]=tmp[i]
+            if ndata == maxData:
+                self.writeSparseList(NNonZero, dtype, indexList, ndata, nrec, valList)
+                nrec = nrec - 1;
+                ndata = 0
 
         if ndata != 0:
+            indexList=indexList[0:ndata]
+            valList=valList[0:ndata]
             self.writeSparseList(NNonZero, dtype, indexList, ndata, nrec, valList)
 
     def writeSparseList(self, NNonZero, dtype, indexList, ndata, nrec, valList):

--- a/harpy/Header.py
+++ b/harpy/Header.py
@@ -141,7 +141,7 @@ class Header(HeaderData):
     @HeaderName.setter
     def HeaderName(self, string4):
         if not isinstance(string4, str): raise Exception('Name not a string')
-        if not len(string4) <= 4: raise Exception('Header name has to be shorter than 5')
+        if not len(string4) <= 4: raise Exception('Header name has to be shorter than 5. Name is '+string4)
         self._HeaderName = string4
 
     @property
@@ -184,9 +184,9 @@ class Header(HeaderData):
             raise Exception("Version 1 Headers can only have scalar or vectorial string data")
         else:
             if "int" in dtype and array.ndim>2:
-                raise Exception("Version 1 Headers can only have up to 2D string data")
+                raise Exception("Version 1 Headers can only have up to 2D integer data")
             elif "float" in dtype and array.ndim > 7:
-                raise Exception("Version 1 Headers can only have up to 2D string data")
+                raise Exception("Version 1 Headers can only have up to 7D Real data")
             if "64" in dtype: raise Exception("Can only write 4byte data in Version 1 Headers")
         if self._setNames:
             if len(self._setNames) != array.ndim: raise Exception("Mismatch between data and set rank")
@@ -238,9 +238,11 @@ class Header(HeaderData):
         Will fail if set is not in Header
         """
         if not isinstance(elDict,dict): raise Exception("Argument for SetElements needs to be dict")
+        if not all([setn in elDict for setn in self._setNames]):
+            raise Exception("Can not set Elements as set is not present in Header")
         for key,val in elDict.items():
-            if not any ([key.strip()== setn.strip() for setn in self._setNames]):
-                raise Exception("Can not set Elements as set is not present in Header")
+            if not key.strip() in  self._setNames : continue
+                #raise Exception("Can not set Elements as set is not present in Header")
             indices=[i for i,set in enumerate(self._setNames) if key.strip() == set.strip()]
             if val:
                 if not all([(isinstance(item, str)) for item in val]):

--- a/harpy/HeaderCommonIO.py
+++ b/harpy/HeaderCommonIO.py
@@ -141,3 +141,4 @@ def writeHeader7D(Head):
         Head.f.write7DDataFull(np.asfortranarray(Head._DataObj), 'f')
     else:
         Head.f.write7DSparseObj(np.asfortranarray(Head._DataObj), 'f')
+


### PR DESCRIPTION
use np.nonzero to get indicies and preallocate the lists for sparse write. 100x speedup
fix error messages to have correct type.
fix logical error in setel dict vs set comparison. Set has to be in dict keys but not the other way around