### PR TITLE
Removed inheritance of dict

### DIFF
--- a/harpy/har_file_io.py
+++ b/harpy/har_file_io.py
@@ -72,7 +72,7 @@ class HarFileInfoObj(object):
         valid=os.path.isfile(self.filename)
         if valid:
             valid= self.mtime == os.path.getmtime(self.filename)
-
+        return valid
 
 class HarFileIO(object):
 

--- a/harpy/header_array.py
+++ b/harpy/header_array.py
@@ -17,7 +17,7 @@ class HeaderArrayObj(dict):
         :return:
         """
 
-        required_keys = ["array", "name", "long_name", "data_type", "version", "storage_type", "file_dims"]
+        required_keys = ["array", "long_name", "data_type", "version", "storage_type", "file_dims"]
         key_present = [key in self for key in required_keys]
 
         if not all(key_present):
@@ -27,12 +27,12 @@ class HeaderArrayObj(dict):
             else:
                 return False
 
-        if (not isinstance(self["name"], str)) or (len(self["name"]) != 4):
-            if raise_exception:
-                raise HeaderArrayObj.InvalidHeaderArrayName(
-                    "Header array name (%s) must be precisely four (alphanumeric) characters." % self["name"])
-            else:
-                return False
+        # if (not isinstance(self["name"], str)) or (len(self["name"]) != 4):
+        #     if raise_exception:
+        #         raise HeaderArrayObj.InvalidHeaderArrayName(
+        #             "Header array name (%s) must be precisely four (alphanumeric) characters." % self["name"])
+        #     else:
+        #         return False
 
         if not isinstance(self["array"], np.ndarray):
             if raise_exception:
@@ -66,7 +66,7 @@ class HeaderArrayObj(dict):
 
 
     @staticmethod
-    def HeaderArrayFromData(name: str, array: np.ndarray, coeff_name: str=None, long_name: str=None,
+    def HeaderArrayFromData(array: np.ndarray, coeff_name: str=None, long_name: str=None,
                             version: int=1, storage_type=None, file_dims=None, data_type=None,
                             sets: 'Union[None, List[dict]]'=None):
         """
@@ -94,19 +94,15 @@ class HeaderArrayObj(dict):
 
         # Defaults handling
         if coeff_name is None:
-            coeff_name = name
+            coeff_name = " "*12
         if long_name is None:
             long_name = coeff_name
 
-        # String padding if necessary
-        if len(name) < 4:
-            name = name.ljust(4)
         if len(coeff_name) < 12:
             coeff_name = coeff_name.ljust(12)
         if len(long_name) < 70:
             long_name = long_name.ljust(70)
 
-        hao["name"] = name
         hao["array"] = array
         hao["coeff_name"] = coeff_name
         hao["long_name"] = long_name
@@ -129,7 +125,7 @@ class HeaderArrayObj(dict):
         :return: A new ``HeaderArrayObj`` that results from the operation. Will have a default header name of ``"NEW1"``.
         """
         new_array = getattr(self["array"], operation)(other["array"])
-        return HeaderArrayObj.HeaderArrayFromData(name="NEW1", array=new_array, **kwargs)
+        return HeaderArrayObj.HeaderArrayFromData(array=new_array, **kwargs)
 
     def __add__(self, other):
         return self.array_operation(other, "__add__")
@@ -155,9 +151,6 @@ class HeaderArrayObj(dict):
     def __sub__(self, other):
         return self.array_operation(other, "__sub__")
 
-    class InvalidHeaderArrayName(ValueError):
-        """Raised if header array name is not exactly four (alphanumeric) characters long."""
-        pass
 
     class UnsupportedArrayType(TypeError):
         """Raised if invalid array type passed."""

--- a/harpy/tests/test_har_file.py
+++ b/harpy/tests/test_har_file.py
@@ -79,7 +79,10 @@ class TestHarFileObj(unittest.TestCase):
 
         self.assertTrue(all([x == y for (x, y) in zip(hn, test_hn)]))
 
-        hfo.addHeaderArrayObjs(hao)
+        hfo.addHeaderArrayObjs("INTA", hao)
+
+        with self.assertRaises(HarFileObj.InvalidHeaderArrayName):
+            hfo.addHeaderArrayObjs("TOO LONG NAME", hao)
 
         hn = hfo.getHeaderArrayNames()
         test_hn = ['XXCD', 'XXCR', 'XXCP', 'XXHS', 'CHST', 'SIMP', 'SIM2', 'NH01', 'ARR7', 'INTA']

--- a/harpy/tests/test_har_file_io.py
+++ b/harpy/tests/test_har_file_io.py
@@ -24,7 +24,7 @@ class TestHarFileIO(unittest.TestCase):
     def test_read_har_file_info(self):
         hfi = HarFileIO.readHarFileInfo(TestHarFileIO._dd + "test.har")
         # header_names = list(hfi["headers"].keys())
-        header_names = [ha_info["name"] for ha_info in hfi["ha_infos"]]
+        header_names = hfi.getHeaderArrayNames()
         test_hn = ['XXCD', 'XXCR', 'XXCP', 'XXHS', 'CHST', 'INTA', 'SIMP', 'SIM2', 'NH01', 'ARR7']
 
         self.assertTrue(all([x == y for (x,y) in zip(header_names, test_hn)]))
@@ -80,11 +80,11 @@ class TestHarFileIO(unittest.TestCase):
         self.assertTrue(chst_header.is_valid())
 
         chst_header["array"][0] = "F_string" # Change one element
-        HarFileIO.writeHeaders("temp.har", chst_header)
+        HarFileIO.writeHeaders("temp.har", ["CHST"], chst_header)
 
         hfi = HarFileIO.readHarFileInfo("temp.har")
         test_hn = ['CHST']
-        hfi_headers = [ha_info["name"] for ha_info in hfi["ha_infos"]]
+        hfi_headers = hfi.getHeaderArrayNames()
         self.assertTrue(all([x == y for (x, y) in zip(hfi_headers, test_hn)]))
 
         chst_header = HarFileIO.readHeader(hfi, "CHST")
@@ -102,7 +102,7 @@ class TestHarFileIO(unittest.TestCase):
         self.assertTrue(inta_header.is_valid())
 
         inta_header["array"][3,3] = 30
-        HarFileIO.writeHeaders("temp.har", inta_header)
+        HarFileIO.writeHeaders("temp.har", ["INTA"], inta_header)
 
         hfi = HarFileIO.readHarFileInfo("temp.har")
         inta_header = HarFileIO.readHeader(hfi, "INTA")
@@ -119,7 +119,7 @@ class TestHarFileIO(unittest.TestCase):
         self.assertTrue(arr7_header.is_valid())
 
         arr7_header["array"][1, 1, 1, 1, 1, 1, 1] = 103.14
-        HarFileIO.writeHeaders("temp.har", arr7_header)
+        HarFileIO.writeHeaders("temp.har", ["ARR7"], arr7_header)
 
         hfi = HarFileIO.readHarFileInfo("temp.har")
         inta_header = HarFileIO.readHeader(hfi, "ARR7")
@@ -142,7 +142,7 @@ class TestHarFileIO(unittest.TestCase):
         nh01 = HarFileIO.readHeader(hfi, "NH01")
         arr7 = HarFileIO.readHeader(hfi, "ARR7")
 
-        HarFileIO.writeHeaders("temp.har", [nh01, arr7])
+        HarFileIO.writeHeaders("temp.har", ["NH01", "ARR7"],[nh01, arr7])
 
         hfi = HarFileIO.readHarFileInfo("temp.har")
         hn = hfi.getHeaderArrayNames()

--- a/harpy/tests/test_header_array.py
+++ b/harpy/tests/test_header_array.py
@@ -33,18 +33,17 @@ class TestHeaderArray(unittest.TestCase):
         array_7d = np.array(list(range(2**7)))
         array_7d.reshape((2, 2, 2, 2, 2, 2, 2))
 
-        with self.assertRaises(HeaderArrayObj.InvalidHeaderArrayName):
-            HeaderArrayObj.HeaderArrayFromData(name="NAME_THAT_IS_TOO_LONG", array=array_1d)
 
-        hao = HeaderArrayObj.HeaderArrayFromData(name="ARR1", array=array_1d)
+
+        hao = HeaderArrayObj.HeaderArrayFromData(array=array_1d)
         self.assertTrue(hao.is_valid())
         # TODO: Include array type-checking
 
-        hao = HeaderArrayObj.HeaderArrayFromData(name="ARR2", array=array_2d)
+        hao = HeaderArrayObj.HeaderArrayFromData(array=array_2d)
         self.assertTrue(hao.is_valid())
         # TODO: Include array type-checking
 
-        hao = HeaderArrayObj.HeaderArrayFromData(name="ARR7", array=array_7d)
+        hao = HeaderArrayObj.HeaderArrayFromData(array=array_7d)
         self.assertTrue(hao.is_valid())
         # TODO: Include array type-checking
 
@@ -52,8 +51,8 @@ class TestHeaderArray(unittest.TestCase):
 
         array_2d = np.array([[1.0, 2.0], [3.0, 4.0]])
 
-        hao1 = HeaderArrayObj.HeaderArrayFromData(name="ARRA", array=array_2d)
-        hao2 = HeaderArrayObj.HeaderArrayFromData(name="ARRB", array=array_2d)
+        hao1 = HeaderArrayObj.HeaderArrayFromData( array=array_2d)
+        hao2 = HeaderArrayObj.HeaderArrayFromData( array=array_2d)
 
         hao3 = hao1 + hao2
 


### PR DESCRIPTION
Only headerArrayObj is still inheriting from dict. According to google inherit from dict is bad as get and [] aceess can become out of sync.
In most cases an OrderedDict is now part of the structure which uses the header names as keys.
Added mtime to the Info structure. is_valid now checks that the time stamp of the file did not change.
Still need test for this.
 
Removed the HeaderName from the HeaderArrayObj. This is now part of the HarFileObj. As the same headerArrayObj might be written to the same file or the same headerArrayObj appears multiple times on the the File having the name in the Array will cause trouble. 
!!!IMPORTANT!!! Unfortunately this changed the interface to addHeaders. This now requests a list of headerNames. In addition the name is not part of the call to HeaderArrayFromData anymore. Concero might need adjustments there. But you might want to delay as I doubt this will be the only interface change.

As far as I can see everything is OK and the tests run through. 